### PR TITLE
Update 1.0.11

### DIFF
--- a/constants.php
+++ b/constants.php
@@ -1,4 +1,4 @@
 <?php
 define('OSM_MAP_SLUG', 'osm-map-elementor');
 define('OSM_PLUGIN_FOLDER', basename(__DIR__) != 'trunk' ? basename(__DIR__) : OSM_MAP_SLUG);
-define('OSM_MAP_VERSION', '1.0.10');
+define('OSM_MAP_VERSION', '1.0.11');

--- a/osm-map.php
+++ b/osm-map.php
@@ -199,6 +199,8 @@ class Widget_OSM_Map extends Widget_Base
                 'options' => [
                     'popup' => 'Popup',
                     'tooltip' => 'Tooltip',
+                    'static_close_on' => 'Static with close',
+                    'static_close_off' => 'Static without close',
                     'none' => 'None'
                 ]
             ]
@@ -332,7 +334,6 @@ class Widget_OSM_Map extends Widget_Base
             ]
         );
 
-
         $this->add_control(
             'pan_control',
             [
@@ -422,6 +423,9 @@ class Widget_OSM_Map extends Widget_Base
                     'dark-matter-dark-purple' => __('Dark Matter Dark Purple', self::$slug),
                     'dark-matter-purple-roads' => __('Dark Matter Purple Roads', self::$slug),
                     'dark-matter-yellow-roads' => __('Dark Matter Yellow Roads', self::$slug),
+                    'stamen-toner' => __('Stamen Toner (Free)', self::$slug),
+                    'stamen-terrain' => __('Stamen Terrain (Free)', self::$slug),
+                    'stamen-watercolor' => __('Stamen Watercolor (Free)', self::$slug),
                     'custom-tile' => __('Custom Map Tile', self::$slug),
                 ]
             ]
@@ -999,6 +1003,35 @@ class Widget_OSM_Map extends Widget_Base
             ]
         );
 
+        $this->add_responsive_control(
+            'title_align',
+            [
+                'label' => __('Alignment', self::$slug),
+                'type' => Controls_Manager::CHOOSE,
+                'options' => [
+                    'left' => [
+                        'title' => __('Left', self::$slug),
+                        'icon' => 'eicon-text-align-left',
+                    ],
+                    'center' => [
+                        'title' => __('Center', self::$slug),
+                        'icon' => 'eicon-text-align-center',
+                    ],
+                    'right' => [
+                        'title' => __('Right', self::$slug),
+                        'icon' => 'eicon-text-align-right',
+                    ],
+                    'justify' => [
+                        'title' => __('Justified', self::$slug),
+                        'icon' => 'eicon-text-align-justify',
+                    ],
+                ],
+                'selectors' => [
+                    '{{WRAPPER}} .marker-tooltip .marker-title' => 'text-align: {{VALUE}};',
+                ],
+            ]
+        );
+        
         $this->add_control(
             'title_color',
             [
@@ -1476,6 +1509,24 @@ class Widget_OSM_Map extends Widget_Base
                     maxZoom: 18
                 }).addTo(map);
 
+                <?php elseif( $settings['geoapify_tile'] == 'stamen-toner'):?>
+                L.tileLayer('https://stamen-tiles.a.ssl.fastly.net/toner/{z}/{x}/{y}.png', {
+                    attribution: 'Map tiles by <a href="http://stamen.com">Stamen Design</a>, under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://www.openstreetmap.org/copyright">ODbL</a>.',
+                    maxZoom: 18
+                }).addTo(map);
+
+                <?php elseif( $settings['geoapify_tile'] == 'stamen-terrain'):?>
+                L.tileLayer('https://stamen-tiles.a.ssl.fastly.net/terrain/{z}/{x}/{y}.jpg', {
+                    attribution: 'Map tiles by <a href="http://stamen.com">Stamen Design</a>, under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://www.openstreetmap.org/copyright">ODbL</a>.',
+                    maxZoom: 18
+                }).addTo(map);
+
+                <?php elseif( $settings['geoapify_tile'] == 'stamen-watercolor'):?>
+                L.tileLayer('https://stamen-tiles.a.ssl.fastly.net/watercolor/{z}/{x}/{y}.jpg', {
+                    attribution: 'Map tiles by <a href="http://stamen.com">Stamen Design</a>, under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://creativecommons.org/licenses/by-sa/3.0">CC BY SA</a>.',
+                    maxZoom: 18
+                }).addTo(map);
+
                 <?php elseif( $settings['geoapify_tile'] == 'custom-tile'):?>
                 L.tileLayer('<?php echo !empty($global_settings['osm_custom']) ? esc_textarea(__($global_settings['osm_custom'], self::$slug)) : null; ?>', {
                     attribution: '<a href="<?php echo !empty($global_settings['osm_custom_attribution_url']) ? esc_textarea(__($global_settings['osm_custom_attribution_url'], self::$slug)) : null; ?>" target="_blank"><?php echo !empty($global_settings['osm_custom_attribution']) ? esc_textarea(__($global_settings['osm_custom_attribution'], self::$slug)) : null; ?></a> | © OpenStreetMap <a href="https://www.openstreetmap.org/copyright" target="_blank">contributors</a>',
@@ -1655,6 +1706,15 @@ class Widget_OSM_Map extends Widget_Base
                                 case 'popup':
                                     marker.bindPopup(tooltipContent);
                                     break;
+
+                                case 'static_close_on':
+                                    marker.bindPopup(tooltipContent,{closeOnClick: false, autoClose: false, closeOnEscapeKey: false}).openPopup();
+                                    break;
+                                
+                                case 'static_close_off':
+                                    marker.bindPopup(tooltipContent,{closeOnClick: false, autoClose: false, closeButton: false, closeOnEscapeKey: false}).openPopup();
+                                    break;
+                                    
                                 case 'tooltip':
 
                                     let tooltipOptions = {};

--- a/readme.txt
+++ b/readme.txt
@@ -3,6 +3,7 @@ Plugin Name: OSM Map Widget for Elementor
 Version: 1.0.11
 Author: ACT Innovate
 Author URI: https://github.com/flopperj/osm-map-elementor
+Contributors: garbowza, youngmedianetwork
 Tags: elementor, elementor widget, map widget, open street map, addons
 Requires at least: 5.0
 Tested up to: 5.8

--- a/readme.txt
+++ b/readme.txt
@@ -1,13 +1,14 @@
 === OSM Map Widget for Elementor ===
+Contributors: garbowza, youngmedianetwork
 Plugin Name: OSM Map Widget for Elementor
-Version: 1.0.9
+Version: 1.0.11
 Author: ACT Innovate
 Author URI: https://github.com/flopperj/osm-map-elementor
 Tags: elementor, elementor widget, map widget, open street map, addons
 Requires at least: 5.0
 Tested up to: 5.8
 Requires PHP: 5.6
-Stable tag: 1.0.10
+Stable tag: 1.0.11
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,4 @@
 === OSM Map Widget for Elementor ===
-Contributors: garbowza, youngmedianetwork
 Plugin Name: OSM Map Widget for Elementor
 Version: 1.0.11
 Author: ACT Innovate


### PR DESCRIPTION
**Behavior**
- Add Static Popup Label (with and without Close Button)

**Marker Title**
- Add Title Alignment Option

**New Free Map Tiles**
- Add Stamen Toner
- Add Stamen Terrain
- Add Stamen Watercolor

**GDPR Support**
The plugin supports Tiles Proxy for OpenStreetMap
You only need to set the Tiles (caching) url as Custom Map Tile URL. 
The CSS and JS files are not needed as they are already included in OSM Map Widget for Elementor.