### PR TITLE
Updated the Stamen fastly URLs to the new Stadia Maps ones.

### DIFF
--- a/osm-map.php
+++ b/osm-map.php
@@ -1528,21 +1528,21 @@ class Widget_OSM_Map extends Widget_Base
                 }).addTo(map);
 
                 <?php elseif( $settings['geoapify_tile'] == 'stamen-toner'):?>
-                L.tileLayer('https://stamen-tiles.a.ssl.fastly.net/toner/{z}/{x}/{y}.png', {
-                    attribution: 'Map tiles by <a href="http://stamen.com">Stamen Design</a>, under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://www.openstreetmap.org/copyright">ODbL</a>.',
+                L.tileLayer('https://tiles.stadiamaps.com/tiles/stamen_toner/{z}/{x}/{y}@2x.png', {
+                    attribution: 'Map tiles by &copy; <a href="https://stadiamaps.com/" target="_blank">Stadia Maps</a> &copy; <a href="https://stamen.com/" target="_blank">Stamen Design</a> &copy; <a href="https://openmaptiles.org/" target="_blank">OpenMapTiles</a> &copy; <a href="https://www.openstreetmap.org/about" target="_blank">OpenStreetMap</a> contributors',
                     maxZoom: 18
                 }).addTo(map);
 
                 <?php elseif( $settings['geoapify_tile'] == 'stamen-terrain'):?>
-                L.tileLayer('https://stamen-tiles.a.ssl.fastly.net/terrain/{z}/{x}/{y}.jpg', {
-                    attribution: 'Map tiles by <a href="http://stamen.com">Stamen Design</a>, under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://www.openstreetmap.org/copyright">ODbL</a>.',
+                L.tileLayer('https://tiles.stadiamaps.com/tiles/stamen_terrain/{z}/{x}/{y}@2x.png', {
+                    attribution: 'Map tiles by &copy; <a href="https://stadiamaps.com/" target="_blank">Stadia Maps</a> &copy; <a href="https://stamen.com/" target="_blank">Stamen Design</a> &copy; <a href="https://openmaptiles.org/" target="_blank">OpenMapTiles</a> &copy; <a href="https://www.openstreetmap.org/about" target="_blank">OpenStreetMap</a> contributors',
                     maxZoom: 18
                 }).addTo(map);
 
                 <?php elseif( $settings['geoapify_tile'] == 'stamen-watercolor'):?>
-                L.tileLayer('https://stamen-tiles.a.ssl.fastly.net/watercolor/{z}/{x}/{y}.jpg', {
-                    attribution: 'Map tiles by <a href="http://stamen.com">Stamen Design</a>, under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://creativecommons.org/licenses/by-sa/3.0">CC BY SA</a>.',
-                    maxZoom: 18
+                L.tileLayer('https://tiles.stadiamaps.com/tiles/stamen_watercolor/{z}/{x}/{y}.jpg', {
+                    attribution: 'Map tiles by &copy; <a href="https://stadiamaps.com/" target="_blank">Stadia Maps</a> &copy; <a href="https://stamen.com/" target="_blank">Stamen Design</a> &copy; <a href="https://www.openstreetmap.org/about" target="_blank">OpenStreetMap</a> contributors',
+                    maxZoom: 16
                 }).addTo(map);
 
                 <?php elseif( $settings['geoapify_tile'] == 'custom-tile'):?>


### PR DESCRIPTION
Stamen partnered with Stadia Maps for hosting their tiles.  I have updated the URLs to the new ones hosted at Stadia Maps, along with the appropriate attributions.

Toner and Terrain are both retina (2x), while Watercolor is not.  Also, Watercolor is best viewed at zooms at 16 and less.

More info about this update can be found here:  https://stadiamaps.com/stamen/

Stadia Maps supports domain authentication, so we do not need to add API key support at this time. Stadia Maps also supports API keys by appending _?api_key=YOUR-API-KEY_ to the call.

