### PR TITLE
Remove deprecated code

### DIFF
--- a/osm-map.php
+++ b/osm-map.php
@@ -12,7 +12,6 @@ use Elementor\Core\Kits\Documents\Tabs\Global_Colors;
 use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
 use Elementor\Core\Breakpoints\Manager;
 //Use Breakpoints Manager via `Plugin::$instance->breakpoints`; //Deprecation Elementor\Core\Responsive\Responsive 3.6
-use Elementor\Core\Schemes\Typography;
 use Elementor\Widget_Base;
 use Elementor\Repeater;
 use Elementor\Controls_Manager;
@@ -1186,7 +1185,9 @@ class Widget_OSM_Map extends Widget_Base
             [
                 'name' => 'content_typography',
                 'label' => __('Typography', self::$slug),
-                'scheme' => Typography::TYPOGRAPHY_1,
+                'global' => [
+                    'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+                ],
                 'selector' => '{{WRAPPER}} .marker-content .marker-description',
             ]
         );

--- a/osm-map.php
+++ b/osm-map.php
@@ -11,7 +11,6 @@ require_once('constants.php');
 use Elementor\Core\Kits\Documents\Tabs\Global_Colors;
 use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
 use Elementor\Core\Breakpoints\Manager;
-//Use Breakpoints Manager via `Plugin::$instance->breakpoints`; //Deprecation Elementor\Core\Responsive\Responsive 3.6
 use Elementor\Widget_Base;
 use Elementor\Repeater;
 use Elementor\Controls_Manager;
@@ -1444,7 +1443,7 @@ class Widget_OSM_Map extends Widget_Base
         $global_settings = get_option('osm_widget');
         $settings = $this->get_settings_for_display();
         $markers = $this->get_settings_for_display('marker_list');
-        $settings['breakpoints'] = \Elementor\Plugin::$instance->breakpoints->get_breakpoints(); //Deprecation Responsive::get_breakpoints() 3.6
+        $settings['breakpoints'] = \Elementor\Plugin::$instance->breakpoints->get_breakpoints();
 
         if (0 === absint($settings['zoom']['size'])) {
             $settings['zoom']['size'] = 10;


### PR DESCRIPTION
You missed one more "scheme" that should be replaced with "globals".

Furthermore, you need to remove the commented code. Otherwise, Elementor's "Deprecated Code Detector" tool will warn that the plugin has deprecated code.